### PR TITLE
Implement atomic PostTransaction with conservation-of-value check

### DIFF
--- a/db/migrations/000002_chart_of_accounts.sql
+++ b/db/migrations/000002_chart_of_accounts.sql
@@ -1,0 +1,14 @@
+-- Chart of accounts: core system-level ledger accounts.
+-- Per-merchant accounts (e.g. Merchant_Wallet_Pending:merchant_abc)
+-- will be created dynamically during merchant onboarding.
+
+INSERT INTO ledger_accounts (id, name, account_type, normal_balance) VALUES
+    ('a0000000-0000-0000-0000-000000000001', 'Settlement_Pending',        'ASSET',    'DEBIT'),
+    ('a0000000-0000-0000-0000-000000000002', 'Settlement_Assets',         'ASSET',    'DEBIT'),
+    ('a0000000-0000-0000-0000-000000000003', 'Merchant_Wallet_Pending',   'LIABILITY','CREDIT'),
+    ('a0000000-0000-0000-0000-000000000004', 'Merchant_Wallet_Available', 'LIABILITY','CREDIT'),
+    ('a0000000-0000-0000-0000-000000000005', 'Merchant_Bank_Account',     'ASSET',    'DEBIT'),
+    ('a0000000-0000-0000-0000-000000000006', 'Fee_Expense',               'EXPENSE',  'DEBIT'),
+    ('a0000000-0000-0000-0000-000000000007', 'Inbound_Clearing',          'ASSET',    'DEBIT'),
+    ('a0000000-0000-0000-0000-000000000008', 'Currency_Exchange_Loss',    'EXPENSE',  'DEBIT'),
+    ('a0000000-0000-0000-0000-000000000009', 'Rounding_Expense',          'EXPENSE',  'DEBIT');

--- a/db/migrations/000003_ledger_account_constraints.sql
+++ b/db/migrations/000003_ledger_account_constraints.sql
@@ -1,0 +1,9 @@
+-- Tighten ledger_accounts columns from free-text to checked enums.
+
+ALTER TABLE ledger_accounts
+    ADD CONSTRAINT ledger_accounts_type_check
+    CHECK (account_type IN ('ASSET', 'LIABILITY', 'EQUITY', 'EXPENSE', 'REVENUE'));
+
+ALTER TABLE ledger_accounts
+    ADD CONSTRAINT ledger_accounts_normal_balance_check
+    CHECK (normal_balance IN ('DEBIT', 'CREDIT'));

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,7 +105,21 @@ The background path should stay explicit:
 - keep the client focused on operations workflows, not user-facing checkout
 - encode major architectural decisions as ADRs instead of rediscovering them in chat
 
-## Related documents
+## Specification documents
+
+Detailed engineering specifications derived from the design research:
+
+- [spec/payment-flows.md](spec/payment-flows.md) - card, ACH, and dispute flow step-by-step sequences
+- [spec/data-model.md](spec/data-model.md) - complete table definitions, constraints, and indexing strategy
+- [spec/state-machine.md](spec/state-machine.md) - state transition table, terminal states, out-of-order handling
+- [spec/ledger-rules.md](spec/ledger-rules.md) - chart of accounts and deterministic posting rules per event
+- [spec/provider-interface.md](spec/provider-interface.md) - unified provider interface, error taxonomy, retry logic
+- [spec/webhook-processing.md](spec/webhook-processing.md) - inbox pattern, signature verification, async workers
+- [spec/idempotency.md](spec/idempotency.md) - key strategy, request hashing, replay and conflict handling
+- [spec/reconciliation.md](spec/reconciliation.md) - three-way match algorithm, tolerance rules, drift detection
+- [spec/failure-handling.md](spec/failure-handling.md) - ambiguous failure scenarios, hard constraints, production pitfalls
+
+## Architecture decision records
 
 - [adr/0000-template.md](adr/0000-template.md)
 - [adr/0001-go-postgres-typescript-foundation.md](adr/0001-go-postgres-typescript-foundation.md)

--- a/docs/spec/data-model.md
+++ b/docs/spec/data-model.md
@@ -1,0 +1,129 @@
+# Data Model Specification
+
+PostgreSQL is the authoritative system of record.
+The initial migration in `db/migrations/000001_initial.sql` establishes the baseline.
+This document is the reference for column semantics, constraints, and indexing strategy.
+
+## Core Transactional Tables
+
+### payments
+
+The primary intent and high-level business entity.
+
+| Column | Type | Constraints | Description |
+|---|---|---|---|
+| id | UUID | PRIMARY KEY | Unique internal ID |
+| merchant_id | UUID | NOT NULL, INDEX | Reference to the business |
+| external_id | TEXT | NOT NULL, INDEX | Merchant's reference (e.g. Order ID) |
+| amount | NUMERIC(19,4) | NOT NULL, CHECK > 0 | Total amount in base units |
+| currency | CHAR(3) | NOT NULL | ISO 4217 code |
+| status | TEXT | NOT NULL | CREATED, AUTHORIZED, CAPTURED, etc. |
+| metadata | JSONB | NULLABLE | Extensible business data |
+| created_at | TIMESTAMPTZ | NOT NULL, DEFAULT NOW | Audit timestamp |
+
+### payment_attempts
+
+Payments may have multiple attempts across different providers if retries are enabled.
+
+| Column | Type | Constraints | Description |
+|---|---|---|---|
+| id | UUID | PRIMARY KEY | Unique attempt ID |
+| payment_id | UUID | NOT NULL, FK(payments) ON DELETE RESTRICT | Parent payment |
+| provider_id | TEXT | NOT NULL | e.g. 'stripe', 'paypal' |
+| provider_ref | TEXT | UNIQUE, INDEX | ID provided by the PSP |
+| attempt_type | TEXT | NOT NULL | AUTH, CAPTURE, REFUND |
+| status | TEXT | NOT NULL | SUCCESS, FAILED, PENDING |
+| error_code | TEXT | NULLABLE | Normalized error code (see provider-interface.md) |
+| raw_response | JSONB | NULLABLE | Exact response from the provider |
+| created_at | TIMESTAMPTZ | NOT NULL, DEFAULT NOW | Audit timestamp |
+
+Future constraint: unique partial index on (payment_id, attempt_type) WHERE status = 'SUCCESS'
+to ensure only one successful capture or refund per payment.
+
+## Ledger Tables
+
+Three tables enforce a strict double-entry system.
+
+### ledger_accounts
+
+| Column | Type | Constraints | Description |
+|---|---|---|---|
+| id | UUID | PRIMARY KEY | Unique account ID |
+| name | TEXT | NOT NULL | e.g. 'Settlement_Assets', 'Merchant_Wallet:abc' |
+| account_type | TEXT | NOT NULL | ASSET, LIABILITY, EQUITY, EXPENSE, REVENUE |
+| normal_balance | TEXT | NOT NULL | DEBIT or CREDIT |
+| created_at | TIMESTAMPTZ | NOT NULL, DEFAULT NOW | Audit timestamp |
+
+### ledger_transactions
+
+Groups a set of balancing entries into one atomic unit.
+
+| Column | Type | Constraints | Description |
+|---|---|---|---|
+| id | UUID | PRIMARY KEY | Unique transaction ID |
+| payment_id | UUID | FK(payments) ON DELETE RESTRICT | Related payment |
+| reference | TEXT | NOT NULL | Human-readable description |
+| created_at | TIMESTAMPTZ | NOT NULL, DEFAULT NOW | Audit timestamp |
+
+### ledger_entries
+
+| Column | Type | Constraints | Description |
+|---|---|---|---|
+| id | UUID | PRIMARY KEY | Unique entry ID |
+| transaction_id | UUID | NOT NULL, FK(ledger_transactions) | Groups the balancing entries |
+| account_id | UUID | NOT NULL, FK(ledger_accounts) | The targeted account |
+| debit | NUMERIC(19,4) | NOT NULL, DEFAULT 0, CHECK >= 0 | Debit amount |
+| credit | NUMERIC(19,4) | NOT NULL, DEFAULT 0, CHECK >= 0 | Credit amount |
+| created_at | TIMESTAMPTZ | NOT NULL, DEFAULT NOW | Audit timestamp |
+| CONSTRAINT | ledger_entries_single_side | CHECK | Either debit or credit > 0, not both |
+
+## Reliability and Persistence Tables
+
+### idempotency_keys
+
+| Column | Type | Constraints | Description |
+|---|---|---|---|
+| idempotency_key | TEXT | PRIMARY KEY | Key from the request header |
+| request_hash | TEXT | NOT NULL | SHA-256 hash of request payload |
+| response_code | INT | NOT NULL | Cached HTTP status |
+| response_body | JSONB | NOT NULL | Cached response body |
+| expires_at | TIMESTAMPTZ | INDEX | Expiration time (24h recommended) |
+| created_at | TIMESTAMPTZ | NOT NULL, DEFAULT NOW | Audit timestamp |
+
+### webhook_inbox
+
+| Column | Type | Constraints | Description |
+|---|---|---|---|
+| id | UUID | PRIMARY KEY | Internal ID |
+| provider | TEXT | NOT NULL | e.g. 'stripe' |
+| provider_evt_id | TEXT | UNIQUE | Provider's event ID for deduplication |
+| raw_payload | JSONB | NOT NULL | Raw body as received |
+| status | TEXT | NOT NULL | PENDING, PROCESSED, FAILED |
+| received_at | TIMESTAMPTZ | NOT NULL, DEFAULT NOW | Ingestion timestamp |
+
+### outbox_events
+
+| Column | Type | Constraints | Description |
+|---|---|---|---|
+| id | UUID | PRIMARY KEY | Internal ID |
+| topic | TEXT | NOT NULL | Event type |
+| payload | JSONB | NOT NULL | Event data |
+| status | TEXT | NOT NULL | PENDING, PUBLISHED, FAILED |
+| created_at | TIMESTAMPTZ | NOT NULL, DEFAULT NOW | Creation timestamp |
+
+### reconciliation_runs
+
+| Column | Type | Constraints | Description |
+|---|---|---|---|
+| id | UUID | PRIMARY KEY | Internal ID |
+| provider | TEXT | NOT NULL | Provider being reconciled |
+| status | TEXT | NOT NULL | RUNNING, COMPLETED, FAILED |
+| started_at | TIMESTAMPTZ | NOT NULL, DEFAULT NOW | Start timestamp |
+| completed_at | TIMESTAMPTZ | NULLABLE | Completion timestamp |
+
+## Indexing Strategy
+
+- B-Tree indexes on all foreign keys and created_at columns.
+- Unique partial indexes on payment_attempts(payment_id, attempt_type) WHERE status = 'SUCCESS'.
+- Check constraints enforce non-negative amounts on all financial columns.
+- Foreign keys use ON DELETE RESTRICT to prevent deletion of referenced records.

--- a/docs/spec/failure-handling.md
+++ b/docs/spec/failure-handling.md
@@ -1,0 +1,57 @@
+# Failure Handling Rules
+
+The orchestrator must handle ambiguous failure states where the outcome at the provider is unknown.
+
+## Failure Scenarios
+
+### Provider Success, Local DB Failure
+
+The PSP captures the payment but SpanPay crashes before updating the database.
+
+- The reconciliation engine detects the orphan PSP entry.
+- Auto-heals by updating internal state to SUCCESS and posting missing ledger entries.
+- Logged as a reconciliation auto-heal event.
+
+### Local Success, Provider Timeout
+
+The request to the PSP times out with no response.
+
+1. Transition internal state to UNKNOWN.
+2. Poll the PSP's status API via `QueryStatus`.
+3. If PSP has no record: safe to retry on same or different provider.
+4. If PSP says SUCCESS: update local state to match.
+5. If PSP says FAILED: update local state to FAILED.
+
+### Duplicate Webhook
+
+- The `webhook_inbox` table unique constraint on `provider_evt_id` prevents re-processing.
+- Worker ignores the duplicate event.
+- Returns 200 OK to the provider to stop retries.
+
+### Out-of-Order Dispute
+
+If `dispute.created` webhook arrives before `payment.succeeded` is processed:
+
+1. State machine creates payment in DISPUTED state.
+2. Correctly sequences ledger entries as if payment had succeeded and then been disputed.
+3. All intermediate entries are posted atomically.
+
+## Hard Constraints
+
+These are non-negotiable and must be enforced by code review and automated testing.
+
+1. **Append-Only Ledger**: No SQL UPDATE or DELETE statements on `ledger_entries`.
+2. **Balanced Transactions**: The ledger engine wraps all entries for a transaction in a DB transaction and verifies they sum to zero before committing.
+3. **Internal Ledger Is Source of Truth**: If the PSP says balance is $100 and ledger says $90, the $10 is an error to investigate, not a reason to adjust the ledger.
+4. **No Side Effects in DB Transactions**: Provider API calls and message queue publishes happen after the DB transaction commits, or via the Outbox pattern.
+5. **Strict Idempotency**: Every mutating API endpoint requires an idempotency key. No key means no processing.
+
+## Production Pitfalls
+
+These are subtle issues that surface in real payment systems:
+
+1. **Rounding Gaps**: Multi-currency transactions may use different FX rates between PSP and internal system. Book explicitly to `Currency_Exchange_Loss` account.
+2. **Settlement Delays**: Distinguish between "available at processor" and "liquid in bank."
+3. **Partial Capture Limits**: Many networks allow only one capture per auth. Remaining amount is released.
+4. **Chargeback Fees**: Disputes include non-refundable fees ($15-$25). Must be tracked separately or the ledger will never match bank statements.
+5. **Clock Skew**: Webhook signature verification includes timestamp checks. Server clock drift > 5 minutes breaks all webhook verification.

--- a/docs/spec/idempotency.md
+++ b/docs/spec/idempotency.md
@@ -1,0 +1,62 @@
+# Idempotency Specification
+
+Idempotency is the primary safeguard against the double-spend problem.
+Every API endpoint must accept an Idempotency-Key header.
+
+## Key Strategy
+
+### Format
+
+- Client provides an `Idempotency-Key` header on every mutating request.
+- Keys are scoped per `merchant_id` to prevent cross-business collisions.
+- No key, no request processing (return 400).
+
+### Request Hashing
+
+To prevent key reuse for different payloads:
+
+1. Hash the request body with SHA-256.
+2. Store the hash alongside the key.
+3. If key matches but body hash differs, return `IdempotencyConflictError` (422).
+
+### Storage
+
+- Fast path: distributed cache (Redis with SET NX) for locking during processing.
+- Durable path: `idempotency_keys` SQL table for long-term deduplication.
+- Retention: 30 days recommended, governed by `expires_at` column.
+
+## Request Lifecycle
+
+### First Request
+
+1. Check if key exists in cache or database.
+2. If not found: set key to IN_PROGRESS in cache.
+3. Process the request normally.
+4. On completion: store final HTTP status and response body.
+5. Update key status to COMPLETED.
+
+### Duplicate During Processing
+
+If a second request arrives while the first is still IN_PROGRESS:
+
+- Return 409 Conflict.
+- Client should retry after a short delay.
+
+### Duplicate After Completion
+
+If the key exists and status is COMPLETED:
+
+1. Verify request body hash matches.
+2. If match: return the cached response (same HTTP status and body).
+3. If mismatch: return IdempotencyConflictError (422).
+
+No side effects are triggered. No provider calls, no ledger entries, no state changes.
+
+## Scope
+
+Idempotency applies to all mutating API endpoints:
+
+- POST /payments (create payment intent)
+- POST /payments/:id/capture
+- POST /payments/:id/refund
+- POST /payments/:id/void

--- a/docs/spec/ledger-rules.md
+++ b/docs/spec/ledger-rules.md
@@ -1,0 +1,104 @@
+# Ledger Posting Rules
+
+Deterministic rules mapping business events to accounting entries.
+These rules are enforced by the ledger engine in `server/internal/ledger/`.
+
+## Fundamental Invariants
+
+1. **Conservation of Value**: Sum of debits must equal sum of credits for every transaction.
+2. **Derived Balances**: Balances are computed, never stored as mutable fields.
+   - Credit-normal accounts: Balance = SUM(credits) - SUM(debits)
+   - Debit-normal accounts: Balance = SUM(debits) - SUM(credits)
+3. **Immutability**: Entries are append-only. Corrections create new compensating entries.
+4. **Reference Integrity**: Every entry references a valid ledger_transaction and ledger_account.
+
+## Chart of Accounts
+
+| Account | Type | Normal Balance | Purpose |
+|---|---|---|---|
+| Settlement_Pending | ASSET | DEBIT | Funds reserved at PSP but not yet captured |
+| Settlement_Assets | ASSET | DEBIT | Funds held at PSP/Acquirer post-capture |
+| Merchant_Wallet_Pending | LIABILITY | CREDIT | Funds owed to merchant, pending capture |
+| Merchant_Wallet_Available | LIABILITY | CREDIT | Funds available for merchant payout |
+| Merchant_Bank_Account | ASSET | DEBIT | Funds deposited in merchant's bank |
+| Fee_Expense | EXPENSE | DEBIT | Costs paid to PSPs (processing fees, dispute fees) |
+| Inbound_Clearing | ASSET | DEBIT | Temporary staging for unconfirmed funds |
+| Currency_Exchange_Loss | EXPENSE | DEBIT | FX rounding gaps booked during reconciliation |
+| Rounding_Expense | EXPENSE | DEBIT | Sub-threshold rounding differences |
+
+## Posting Rules by Event
+
+### Payment Authorized
+
+Funds reserved but not yet received.
+
+| Side | Account | Direction |
+|---|---|---|
+| Debit | Settlement_Pending | Asset increases |
+| Credit | Merchant_Wallet_Pending | Liability increases |
+
+Timing: immediately upon successful PSP authorization response.
+
+### Payment Captured
+
+Funds move from pending to available on internal books.
+
+| Side | Account | Direction |
+|---|---|---|
+| Debit | Merchant_Wallet_Pending | Liability decreases |
+| Credit | Merchant_Wallet_Available | Liability increases |
+| Debit | Settlement_Assets | Asset increases |
+| Credit | Settlement_Pending | Asset decreases |
+
+Timing: upon capture success webhook.
+
+### Refund Processed
+
+| Side | Account | Direction |
+|---|---|---|
+| Debit | Merchant_Wallet_Available | Liability decreases |
+| Credit | Settlement_Assets | Asset decreases |
+
+Timing: when PSP confirms refund succeeded.
+
+### Dispute/Chargeback Received
+
+Two sub-transactions, both posted atomically:
+
+Transaction amount reversal:
+
+| Side | Account | Direction |
+|---|---|---|
+| Debit | Merchant_Wallet_Available | Liability decreases |
+| Credit | Settlement_Assets | Asset decreases |
+
+Dispute fee (if applicable):
+
+| Side | Account | Direction |
+|---|---|---|
+| Debit | Fee_Expense | Expense increases |
+| Credit | Settlement_Assets | Asset decreases |
+
+Timing: immediately upon receiving `dispute.created` webhook.
+
+### Dispute Won
+
+Reverses the dispute reversal:
+
+| Side | Account | Direction |
+|---|---|---|
+| Debit | Settlement_Assets | Asset increases |
+| Credit | Merchant_Wallet_Available | Liability increases |
+
+Fee is not reversed (dispute fees are typically non-refundable).
+
+### Bank Payout (Settlement)
+
+Physical funds movement from PSP to merchant's bank.
+
+| Side | Account | Direction |
+|---|---|---|
+| Debit | Merchant_Bank_Account | Asset increases |
+| Credit | Settlement_Assets | Asset decreases |
+
+Timing: during reconciliation of bank statement.

--- a/docs/spec/payment-flows.md
+++ b/docs/spec/payment-flows.md
@@ -1,0 +1,89 @@
+# Payment Flow Specifications
+
+Deterministic step-by-step sequences for each supported payment method.
+Each flow identifies risk points and required verification steps.
+
+## Card Payment Flow: Authorization, Capture, Settlement
+
+The dual-message card flow separates intent to charge from actual funds movement.
+
+### Step 1: Authorization
+
+1. Merchant system sends request to SpanPay orchestrator.
+2. Orchestrator generates internal UUID, records CREATED state.
+3. Ledger posts a Pending entry (Debit: Settlement_Pending, Credit: Merchant_Wallet_Pending).
+4. Orchestrator calls PSP authorization endpoint via provider adapter.
+5. PSP communicates with card network and issuer to verify funds and fraud risk.
+6. On success: state transitions to AUTHORIZED, response returned to merchant.
+7. On failure: state transitions to FAILED (terminal).
+
+Risk: PSP timeout leaves outcome unknown. See failure-handling.md for UNKNOWN state handling.
+
+### Step 2: Capture
+
+1. Merchant triggers Capture request after order fulfillment.
+2. Orchestrator validates state is AUTHORIZED, transitions to PROCESSING.
+3. Calls PSP capture endpoint via provider adapter.
+4. PSP emits capture confirmation webhook asynchronously.
+5. Webhook lands in inbox, async worker transitions state to CAPTURED.
+6. Ledger posts capture entries (moves pending to available).
+
+Constraint: many card networks allow only one capture per authorization.
+Partial capture of $50 on a $100 auth typically releases the remaining $50 immediately.
+
+### Step 3: Settlement
+
+1. Background process where issuer moves funds to acquirer.
+2. Not visible via real-time APIs.
+3. Verified by the reconciliation engine against PSP payout reports.
+
+## ACH Debit Flow with Delayed Return
+
+ACH transactions are pull payments. Funds are not guaranteed until the return window closes.
+
+### Step 1: Initiation
+
+1. Orchestrator initiates debit request via PSP.
+2. PSP accepts and emits PENDING status.
+3. Orchestrator must NOT mark as successful yet.
+
+### Step 2: Batch Processing
+
+1. ODFI groups transaction into NACHA file.
+2. File sent to ACH Operator (Federal Reserve or TCH).
+
+### Step 3: Provisional Settlement
+
+1. Funds deposited into merchant account within 1-3 business days.
+2. Ledger posts provisional credit.
+
+### Step 4: Delayed Return
+
+1. RDFI has up to 60 days (consumer accounts) to return the payment.
+2. Common return codes: R01 (Insufficient Funds), R02 (Account Closed).
+3. Orchestrator handles returns as asynchronous reversals in the ledger.
+
+Risk: the return window means funds are never truly "final" for weeks.
+
+## Dispute and Chargeback Flow
+
+A dispute is an issuer-initiated reversal of a settled payment.
+
+### Notification
+
+PSP receives dispute notice from card network, sends webhook to orchestrator.
+
+### Immediate Reversal
+
+Upon receiving `dispute.created` webhook, the orchestrator must immediately:
+
+1. Debit the merchant's Available balance in the ledger.
+2. This happens before the merchant responds to the dispute.
+3. Reflects reality: the PSP has already seized the funds.
+
+If a dispute fee applies ($15-$25 typical), a separate entry debits Fee_Expense.
+
+### Resolution
+
+- Merchant wins: subsequent webhook triggers a credit entry back to merchant.
+- Merchant loses: the debit stands, funds are permanently reversed.

--- a/docs/spec/provider-interface.md
+++ b/docs/spec/provider-interface.md
@@ -1,0 +1,76 @@
+# Provider Abstraction Layer
+
+A strict interface that normalizes vendor-specific logic into a unified internal format.
+Allows replacing one PSP with another without changing the core ledger or business logic.
+
+## Unified Provider Interface
+
+```go
+// IPaymentProvider defines the contract every PSP adapter must implement.
+type IPaymentProvider interface {
+    // Authorize initiates a charge or authorization hold.
+    Authorize(ctx context.Context, req NormalizedRequest) (NormalizedResponse, error)
+
+    // Capture collects funds from a previously authorized charge.
+    Capture(ctx context.Context, providerRef string, amount int64) (NormalizedResponse, error)
+
+    // Refund reverses a settled transaction (full or partial).
+    Refund(ctx context.Context, providerRef string, amount int64) (NormalizedResponse, error)
+
+    // QueryStatus queries the current status of a transaction at the provider.
+    QueryStatus(ctx context.Context, providerRef string) (NormalizedResponse, error)
+
+    // NormalizeEvent translates a raw webhook payload into an InternalEvent.
+    NormalizeEvent(rawPayload []byte) (InternalEvent, error)
+
+    // VerifyWebhookSignature validates the HMAC signature of an incoming webhook.
+    VerifyWebhookSignature(rawBody []byte, signatureHeader string) error
+}
+```
+
+## Normalized Response
+
+```go
+type NormalizedResponse struct {
+    ProviderRef string
+    Status      AttemptStatus // SUCCESS, FAILED, PENDING
+    ErrorCode   string        // Normalized internal error code, empty on success
+    RawResponse json.RawMessage
+}
+```
+
+## Error Taxonomy
+
+Providers use different codes for the same problem.
+The adapter maps these to internal enums.
+
+| Internal Code | Stripe | PayPal | ACH |
+|---|---|---|---|
+| INSUFFICIENT_FUNDS | insufficient_funds | INSTRUMENT_DECLINED | R01 |
+| CARD_EXPIRED | expired_card | EXPIRED_CREDIT_CARD | N/A |
+| ACCOUNT_CLOSED | N/A | N/A | R02 |
+| FRAUD_BLOCKED | fraudulent | RISK_REJECTION | R29 |
+| TECHNICAL_ERROR | processing_error | INTERNAL_SERVER_ERROR | N/A |
+| RATE_LIMITED | rate_limit | RATE_LIMIT_REACHED | N/A |
+
+## Retry Decisions Based on Error Code
+
+| Error Code | Retryable | Action |
+|---|---|---|
+| INSUFFICIENT_FUNDS | No | Fail permanently |
+| CARD_EXPIRED | No | Fail permanently |
+| FRAUD_BLOCKED | No | Fail permanently |
+| TECHNICAL_ERROR | Yes | Retry on same or different provider |
+| RATE_LIMITED | Yes | Retry with backoff |
+| ACCOUNT_CLOSED | No | Fail permanently |
+
+## MVP Provider: Stripe
+
+The first adapter implements `IPaymentProvider` for Stripe.
+Testing uses the Stripe CLI test mode and webhook forwarding.
+
+Stripe-specific mapping details:
+- Authorization: `POST /v1/payment_intents` with `capture_method=manual`
+- Capture: `POST /v1/payment_intents/:id/capture`
+- Refund: `POST /v1/refunds`
+- Webhooks: `payment_intent.succeeded`, `charge.refunded`, `charge.dispute.created`

--- a/docs/spec/reconciliation.md
+++ b/docs/spec/reconciliation.md
@@ -1,0 +1,73 @@
+# Reconciliation Specification
+
+Reconciliation compares internal records with external reality to ensure no money is missing.
+It is the definitive check on system correctness.
+
+## Three-Way Match
+
+The reconciliation engine matches across three data sources:
+
+1. **Internal Ledger**: what SpanPay thinks happened (entries in `ledger_entries`).
+2. **Provider Settlement Reports**: what the PSP says they processed (e.g. Stripe Payout CSV).
+3. **Bank Statements**: what actually landed in the corporate bank account.
+
+## Algorithm
+
+### Step 1: Data Collection
+
+Fetch settlement file from the PSP via API or SFTP.
+Store raw file for audit trail.
+
+### Step 2: Normalization
+
+Map PSP CSV headers to internal format:
+- `txn_id` -> `provider_ref`
+- `net_amt` -> `amount`
+- `fee` -> `provider_fee`
+
+### Step 3: Matching
+
+Match each row in the settlement report to a `payment_attempt` using `provider_ref`.
+Build three sets: matched, orphan-internal, orphan-external.
+
+### Step 4: Exception Identification
+
+| Exception | Description | Action |
+|---|---|---|
+| Orphan Ledger Entry | Payment SUCCESS internally but not in PSP report | Investigate, may need correction journal |
+| Orphan PSP Entry | Payment in PSP report but not in internal database | Auto-heal: create internal state and ledger entries |
+| Amount Mismatch | Net amount differs from expected (after fees) | Flag for review, book difference if within tolerance |
+
+## Tolerance Rules
+
+- Differences below threshold (e.g. $0.05) due to rounding or minor FX fluctuations
+  are automatically booked to `Rounding_Expense` account.
+- Multi-currency transactions may show FX rate differences;
+  book to `Currency_Exchange_Loss` account.
+
+## Drift Detection
+
+If total balance in `Settlement_Assets` differs from the PSP-reported balance,
+raise an "Unreconciled Drift" alert.
+
+## Repair Strategy
+
+- Finance team posts a "Correction Journal" to the ledger.
+- Original entries are never modified.
+- The correction journal references the reconciliation_run that identified the issue.
+- Complete audit trail of how the books were aligned.
+
+## Auto-Heal: Provider Success, Local DB Failure
+
+If the PSP captured a payment but SpanPay crashed before updating the DB:
+
+1. Reconciliation detects the orphan PSP entry.
+2. Creates the missing internal state (payment in CAPTURED).
+3. Posts the missing ledger entries.
+4. Logs the auto-heal action for audit.
+
+## Schedule
+
+- Daily reconciliation against PSP settlement reports.
+- Weekly reconciliation against bank statements.
+- On-demand reconciliation for specific payment ranges.

--- a/docs/spec/state-machine.md
+++ b/docs/spec/state-machine.md
@@ -1,0 +1,52 @@
+# State Machine Specification
+
+The state machine prevents illegal transitions and handles high concurrency
+of payment events without corruption.
+
+## State Transition Table
+
+| Current State | Triggering Event | Source | Target State |
+|---|---|---|---|
+| NONE | PAYMENT_CREATE | API | CREATED |
+| CREATED | AUTH_SUCCESS | PSP API | AUTHORIZED |
+| CREATED | AUTH_FAILURE | PSP API | FAILED |
+| AUTHORIZED | CAPTURE_REQUEST | API | PROCESSING |
+| PROCESSING | CAPTURE_SUCCESS | Webhook | CAPTURED |
+| AUTHORIZED | VOID_REQUEST | API | VOIDED |
+| CAPTURED | REFUND_REQUEST | API | REFUNDED_PENDING |
+| REFUNDED_PENDING | REFUND_SUCCESS | Webhook | REFUNDED |
+| CAPTURED | DISPUTE_CREATED | Webhook | DISPUTED |
+| DISPUTED | DISPUTE_WON | Webhook | CAPTURED |
+
+## Terminal States
+
+VOIDED, FAILED, and REFUNDED (full) are terminal.
+No further CAPTURE or DISPUTE triggers should be processed once these are reached.
+
+## Idempotent Transitions
+
+If an event would move the machine to its current state
+(e.g. a duplicate CAPTURE_SUCCESS webhook), the machine must:
+
+1. Acknowledge it as success.
+2. Perform no state or ledger changes.
+3. Return the same response as the original transition.
+
+## Out-of-Order Event Handling
+
+If a CAPTURE_SUCCESS webhook arrives before the synchronous AUTH_SUCCESS response
+has committed (due to network lag), the state machine uses a High-Water Mark approach:
+
+1. Transition to the most advanced valid state (CAPTURED).
+2. Skip intermediate states (AUTHORIZED).
+3. Post all required ledger entries for skipped states atomically.
+
+Example: if `dispute.created` arrives before `payment.succeeded` is processed,
+the state machine must create the payment in DISPUTED state and correctly
+sequence the ledger entries as if the payment had succeeded and then been disputed.
+
+## Concurrency
+
+- State transitions must use optimistic locking (version column or SELECT FOR UPDATE).
+- The machine rejects concurrent transitions that would violate the transition table.
+- Webhook workers should use payment_id partitioning to ensure serial processing per payment.

--- a/docs/spec/webhook-processing.md
+++ b/docs/spec/webhook-processing.md
@@ -1,0 +1,71 @@
+# Webhook Processing Specification
+
+Webhooks are unreliable, asynchronous, and out-of-order.
+The orchestrator treats them as raw data ingress, not instructions.
+
+## Ingestion Pipeline (Inbox Pattern)
+
+### Step 1: Fast Ack
+
+The webhook endpoint must:
+
+1. Verify signature.
+2. Persist raw payload to `webhook_inbox` table.
+3. Return 200 OK within 1-2 seconds.
+
+Any longer risks the provider timing out and retrying, creating duplicate events.
+
+### Step 2: Signature Verification
+
+- Use the provider's shared secret and HMAC-SHA256.
+- Verification must happen against the raw body bytes.
+- Do not parse JSON before verification (whitespace changes break the signature).
+- Include timestamp check with a 5-minute tolerance to guard against replay attacks.
+
+Clock skew warning: if the server clock drifts more than 5 minutes from the PSP's clock,
+all webhooks will fail verification.
+
+### Step 3: Persistence
+
+- Store the raw payload in `webhook_inbox` with status PENDING.
+- The unique constraint on `provider_evt_id` is the final defense against duplicate webhooks.
+- If the insert conflicts (duplicate), acknowledge 200 OK and skip.
+
+### Step 4: Deduplication
+
+- Database-level unique constraint on `provider_evt_id` handles exact duplicates.
+- The state machine handles semantic duplicates (same event type for same payment).
+
+## Async Processing
+
+### Worker Strategy
+
+- A pool of background workers pulls PENDING items from `webhook_inbox`.
+- Workers use payment_id partitioning (hash of payment_id modulo worker count).
+- This ensures one payment is handled by one worker at a time, preventing race conditions.
+
+### Processing Steps
+
+1. Worker picks up inbox item.
+2. Calls provider adapter's `NormalizeEvent` to produce an `InternalEvent`.
+3. Applies the event to the state machine.
+4. If the state machine accepts the transition, writes ledger entries and outbox events atomically.
+5. Marks inbox item as PROCESSED.
+
+### Ordering Logic
+
+Do not rely on timestamps for ordering.
+The state machine itself handles ordering:
+
+- If an "old" event (e.g. `invoice.created`) arrives after a "new" event (`invoice.paid`),
+  the state machine rejects the transition because PAID is a more advanced state.
+- The High-Water Mark approach automatically resolves out-of-order delivery.
+
+### Poison Events
+
+If an event fails processing 5 times:
+
+1. Mark inbox item as FAILED.
+2. Move to Dead Letter Queue (separate table or queue).
+3. Alert operations team for manual investigation.
+4. Do not block processing of other events.

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,3 +1,5 @@
 module github.com/shikarii/spanpay/server
 
 go 1.24
+
+require github.com/google/uuid v1.6.0 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -1,0 +1,2 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/server/internal/ledger/accounts.go
+++ b/server/internal/ledger/accounts.go
@@ -1,0 +1,34 @@
+package ledger
+
+// System-level ledger account IDs.
+// These match the seed data in db/migrations/000002_chart_of_accounts.sql.
+const (
+	AcctSettlementPending      = "a0000000-0000-0000-0000-000000000001"
+	AcctSettlementAssets       = "a0000000-0000-0000-0000-000000000002"
+	AcctMerchantWalletPending  = "a0000000-0000-0000-0000-000000000003"
+	AcctMerchantWalletAvail    = "a0000000-0000-0000-0000-000000000004"
+	AcctMerchantBankAccount    = "a0000000-0000-0000-0000-000000000005"
+	AcctFeeExpense             = "a0000000-0000-0000-0000-000000000006"
+	AcctInboundClearing        = "a0000000-0000-0000-0000-000000000007"
+	AcctCurrencyExchangeLoss   = "a0000000-0000-0000-0000-000000000008"
+	AcctRoundingExpense        = "a0000000-0000-0000-0000-000000000009"
+)
+
+// AccountType enumerates the valid ledger account classifications.
+type AccountType string
+
+const (
+	AccountTypeAsset     AccountType = "ASSET"
+	AccountTypeLiability AccountType = "LIABILITY"
+	AccountTypeEquity    AccountType = "EQUITY"
+	AccountTypeExpense   AccountType = "EXPENSE"
+	AccountTypeRevenue   AccountType = "REVENUE"
+)
+
+// NormalBalance indicates which side increases the account.
+type NormalBalance string
+
+const (
+	NormalDebit  NormalBalance = "DEBIT"
+	NormalCredit NormalBalance = "CREDIT"
+)

--- a/server/internal/ledger/accounts.go
+++ b/server/internal/ledger/accounts.go
@@ -3,15 +3,15 @@ package ledger
 // System-level ledger account IDs.
 // These match the seed data in db/migrations/000002_chart_of_accounts.sql.
 const (
-	AcctSettlementPending      = "a0000000-0000-0000-0000-000000000001"
-	AcctSettlementAssets       = "a0000000-0000-0000-0000-000000000002"
-	AcctMerchantWalletPending  = "a0000000-0000-0000-0000-000000000003"
-	AcctMerchantWalletAvail    = "a0000000-0000-0000-0000-000000000004"
-	AcctMerchantBankAccount    = "a0000000-0000-0000-0000-000000000005"
-	AcctFeeExpense             = "a0000000-0000-0000-0000-000000000006"
-	AcctInboundClearing        = "a0000000-0000-0000-0000-000000000007"
-	AcctCurrencyExchangeLoss   = "a0000000-0000-0000-0000-000000000008"
-	AcctRoundingExpense        = "a0000000-0000-0000-0000-000000000009"
+	AcctSettlementPending     = "a0000000-0000-0000-0000-000000000001"
+	AcctSettlementAssets      = "a0000000-0000-0000-0000-000000000002"
+	AcctMerchantWalletPending = "a0000000-0000-0000-0000-000000000003"
+	AcctMerchantWalletAvail   = "a0000000-0000-0000-0000-000000000004"
+	AcctMerchantBankAccount   = "a0000000-0000-0000-0000-000000000005"
+	AcctFeeExpense            = "a0000000-0000-0000-0000-000000000006"
+	AcctInboundClearing       = "a0000000-0000-0000-0000-000000000007"
+	AcctCurrencyExchangeLoss  = "a0000000-0000-0000-0000-000000000008"
+	AcctRoundingExpense       = "a0000000-0000-0000-0000-000000000009"
 )
 
 // AccountType enumerates the valid ledger account classifications.

--- a/server/internal/ledger/service.go
+++ b/server/internal/ledger/service.go
@@ -1,0 +1,84 @@
+package ledger
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// DBTX abstracts *sql.DB and *sql.Tx so callers can provide either.
+type DBTX interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+// Transaction is the result of a successful PostTransaction call.
+type Transaction struct {
+	ID        string
+	Reference string
+	Entries   []Entry
+}
+
+// PostTransaction validates and atomically persists a set of ledger entries.
+// It enforces conservation of value: the entries must balance before any write.
+// The caller must provide a *sql.Tx to ensure atomicity with surrounding work.
+func PostTransaction(ctx context.Context, tx DBTX, paymentID, reference string, entries []Entry) (*Transaction, error) {
+	if err := ValidateBalanced(entries); err != nil {
+		return nil, fmt.Errorf("ledger validation: %w", err)
+	}
+
+	txnID := uuid.New().String()
+
+	var paymentArg any
+	if paymentID != "" {
+		paymentArg = paymentID
+	}
+
+	_, err := tx.ExecContext(ctx,
+		`INSERT INTO ledger_transactions (id, payment_id, reference) VALUES ($1, $2, $3)`,
+		txnID, paymentArg, reference,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("insert ledger_transactions: %w", err)
+	}
+
+	for _, e := range entries {
+		entryID := uuid.New().String()
+		_, err := tx.ExecContext(ctx,
+			`INSERT INTO ledger_entries (id, transaction_id, account_id, debit, credit) VALUES ($1, $2, $3, $4, $5)`,
+			entryID, txnID, e.Account, e.Debit, e.Credit,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("insert ledger_entries: %w", err)
+		}
+	}
+
+	// Verify conservation of value at the database level as a safety net.
+	if err := verifyTransactionBalance(ctx, tx, txnID); err != nil {
+		return nil, err
+	}
+
+	return &Transaction{
+		ID:        txnID,
+		Reference: reference,
+		Entries:   entries,
+	}, nil
+}
+
+func verifyTransactionBalance(ctx context.Context, tx DBTX, txnID string) error {
+	var sumDebit, sumCredit int64
+	row := tx.QueryRowContext(ctx,
+		`SELECT COALESCE(SUM(debit),0), COALESCE(SUM(credit),0) FROM ledger_entries WHERE transaction_id = $1`,
+		txnID,
+	)
+	if err := row.Scan(&sumDebit, &sumCredit); err != nil {
+		return fmt.Errorf("verify balance: %w", err)
+	}
+	if sumDebit != sumCredit {
+		return errors.New("database-level balance check failed: debits != credits")
+	}
+	return nil
+}

--- a/server/internal/ledger/service_test.go
+++ b/server/internal/ledger/service_test.go
@@ -1,0 +1,111 @@
+package ledger
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+)
+
+// mockTx implements DBTX for unit tests.
+// It captures exec calls and can simulate errors.
+// QueryRowContext returns nil since *sql.Row cannot be mocked;
+// full DB-path tests belong in integration tests with a real Postgres.
+type mockTx struct {
+	execCalls []mockExecCall
+	execErr   error
+}
+
+type mockExecCall struct {
+	query string
+	args  []any
+}
+
+func (m *mockTx) ExecContext(_ context.Context, query string, args ...any) (sql.Result, error) {
+	m.execCalls = append(m.execCalls, mockExecCall{query: query, args: args})
+	return mockResult{}, m.execErr
+}
+
+func (m *mockTx) QueryRowContext(_ context.Context, _ string, _ ...any) *sql.Row {
+	return nil
+}
+
+type mockResult struct{}
+
+func (mockResult) LastInsertId() (int64, error) { return 0, nil }
+func (mockResult) RowsAffected() (int64, error) { return 1, nil }
+
+func TestPostTransaction_RejectsUnbalanced(t *testing.T) {
+	mtx := &mockTx{}
+	_, err := PostTransaction(context.Background(), mtx, "", "test", []Entry{
+		{Account: AcctSettlementPending, Debit: 1000, Credit: 0},
+		{Account: AcctMerchantWalletPending, Debit: 0, Credit: 999},
+	})
+	if err == nil {
+		t.Fatal("expected error for unbalanced entries")
+	}
+	if len(mtx.execCalls) != 0 {
+		t.Fatal("expected no DB writes for unbalanced entries")
+	}
+}
+
+func TestPostTransaction_RejectsSingleEntry(t *testing.T) {
+	mtx := &mockTx{}
+	_, err := PostTransaction(context.Background(), mtx, "", "test", []Entry{
+		{Account: AcctSettlementPending, Debit: 1000, Credit: 0},
+	})
+	if err == nil {
+		t.Fatal("expected error for single entry")
+	}
+}
+
+func TestPostTransaction_RejectsEmptyAccount(t *testing.T) {
+	mtx := &mockTx{}
+	_, err := PostTransaction(context.Background(), mtx, "", "test", []Entry{
+		{Account: "", Debit: 1000, Credit: 0},
+		{Account: AcctMerchantWalletPending, Debit: 0, Credit: 1000},
+	})
+	if err == nil {
+		t.Fatal("expected error for empty account")
+	}
+}
+
+func TestPostTransaction_RejectsBothSides(t *testing.T) {
+	mtx := &mockTx{}
+	_, err := PostTransaction(context.Background(), mtx, "", "test", []Entry{
+		{Account: AcctSettlementPending, Debit: 500, Credit: 500},
+		{Account: AcctMerchantWalletPending, Debit: 0, Credit: 0},
+	})
+	if err == nil {
+		t.Fatal("expected error for entry with both debit and credit")
+	}
+}
+
+func TestPostTransaction_PropagatesExecError(t *testing.T) {
+	mtx := &mockTx{execErr: errors.New("db connection lost")}
+	_, err := PostTransaction(context.Background(), mtx, "", "test", []Entry{
+		{Account: AcctSettlementPending, Debit: 1000, Credit: 0},
+		{Account: AcctMerchantWalletPending, Debit: 0, Credit: 1000},
+	})
+	if err == nil {
+		t.Fatal("expected error from DB failure")
+	}
+}
+
+func TestPostTransaction_CallsInsertBeforeVerify(t *testing.T) {
+	mtx := &mockTx{}
+	// PostTransaction will succeed through inserts but panic on nil Row from
+	// QueryRowContext. We use recover to verify inserts happened.
+	func() {
+		defer func() { recover() }()
+		PostTransaction(context.Background(), mtx, "pay_123", "authorize", []Entry{
+			{Account: AcctSettlementPending, Debit: 1000, Credit: 0},
+			{Account: AcctMerchantWalletPending, Debit: 0, Credit: 1000},
+		})
+	}()
+
+	// Should have: 1 ledger_transactions insert + 2 ledger_entries inserts.
+	if len(mtx.execCalls) != 3 {
+		t.Fatalf("expected 3 exec calls, got %d", len(mtx.execCalls))
+	}
+}


### PR DESCRIPTION
## Summary

- Add `PostTransaction` function in `server/internal/ledger/service.go`
- Validates entries are balanced in-memory before any DB write
- Inserts `ledger_transactions` and `ledger_entries` atomically via caller-provided `DBTX`
- Post-insert DB-level sum verification as a safety net
- 6 unit tests covering rejection paths and insert verification
- Adds `github.com/google/uuid` dependency

## Linked Issue

Closes https://github.com/shikarii/SpanPay/issues/8

## Validation

```
go test ./internal/ledger/ -v -count=1  # 9 tests pass
go build ./...                           # compiles clean
```

## Risks and Tradeoffs

- `DBTX` interface uses `*sql.Row` return from `QueryRowContext`, which makes pure mocking harder. The DB verification path is tested via integration tests (#10) rather than unit mocks.
- `uuid.New()` generates entry IDs at the application level rather than via `gen_random_uuid()` in Postgres, keeping the function testable without a live DB.

## Adversarial Review

- Unbalanced entries: rejected before any DB write
- Missing accounts: caught by FK constraint at DB level
- Concurrent posts: atomicity depends on the caller wrapping in `*sql.Tx`