### PR TITLE
Implement DeriveBalance queries for ledger accounts

### DIFF
--- a/server/internal/ledger/balance.go
+++ b/server/internal/ledger/balance.go
@@ -1,0 +1,114 @@
+package ledger
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// Balance represents a derived account balance at a point in time.
+type Balance struct {
+	AccountID     string
+	NormalBalance NormalBalance
+	Amount        int64
+}
+
+// DeriveBalance computes the current balance for a single account.
+// Credit-normal: SUM(credits) - SUM(debits).
+// Debit-normal:  SUM(debits) - SUM(credits).
+func DeriveBalance(ctx context.Context, tx DBTX, accountID string) (*Balance, error) {
+	var normalBal string
+	var sumDebit, sumCredit int64
+
+	row := tx.QueryRowContext(ctx, `
+		SELECT a.normal_balance,
+		       COALESCE(SUM(e.debit), 0),
+		       COALESCE(SUM(e.credit), 0)
+		FROM ledger_accounts a
+		LEFT JOIN ledger_entries e ON e.account_id = a.id
+		WHERE a.id = $1
+		GROUP BY a.normal_balance`,
+		accountID,
+	)
+	if err := row.Scan(&normalBal, &sumDebit, &sumCredit); err != nil {
+		return nil, fmt.Errorf("derive balance for %s: %w", accountID, err)
+	}
+
+	amount := balanceAmount(NormalBalance(normalBal), sumDebit, sumCredit)
+	return &Balance{
+		AccountID:     accountID,
+		NormalBalance: NormalBalance(normalBal),
+		Amount:        amount,
+	}, nil
+}
+
+// DeriveBalances computes current balances for multiple accounts in one query.
+func DeriveBalances(ctx context.Context, db QueryableDB, accountIDs []string) ([]Balance, error) {
+	if len(accountIDs) == 0 {
+		return nil, nil
+	}
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT a.id, a.normal_balance,
+		       COALESCE(SUM(e.debit), 0),
+		       COALESCE(SUM(e.credit), 0)
+		FROM ledger_accounts a
+		LEFT JOIN ledger_entries e ON e.account_id = a.id
+		WHERE a.id = ANY($1)
+		GROUP BY a.id, a.normal_balance`,
+		accountIDs,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("derive balances: %w", err)
+	}
+	defer rows.Close()
+
+	var balances []Balance
+	for rows.Next() {
+		var id, normalBal string
+		var sumDebit, sumCredit int64
+		if err := rows.Scan(&id, &normalBal, &sumDebit, &sumCredit); err != nil {
+			return nil, fmt.Errorf("scan balance row: %w", err)
+		}
+		balances = append(balances, Balance{
+			AccountID:     id,
+			NormalBalance: NormalBalance(normalBal),
+			Amount:        balanceAmount(NormalBalance(normalBal), sumDebit, sumCredit),
+		})
+	}
+	return balances, rows.Err()
+}
+
+// DeriveBalanceAsOf computes the balance for an account at a specific point in time.
+func DeriveBalanceAsOf(ctx context.Context, tx DBTX, accountID string, asOf time.Time) (*Balance, error) {
+	var normalBal string
+	var sumDebit, sumCredit int64
+
+	row := tx.QueryRowContext(ctx, `
+		SELECT a.normal_balance,
+		       COALESCE(SUM(e.debit), 0),
+		       COALESCE(SUM(e.credit), 0)
+		FROM ledger_accounts a
+		LEFT JOIN ledger_entries e ON e.account_id = a.id AND e.created_at <= $2
+		WHERE a.id = $1
+		GROUP BY a.normal_balance`,
+		accountID, asOf,
+	)
+	if err := row.Scan(&normalBal, &sumDebit, &sumCredit); err != nil {
+		return nil, fmt.Errorf("derive balance as-of for %s: %w", accountID, err)
+	}
+
+	amount := balanceAmount(NormalBalance(normalBal), sumDebit, sumCredit)
+	return &Balance{
+		AccountID:     accountID,
+		NormalBalance: NormalBalance(normalBal),
+		Amount:        amount,
+	}, nil
+}
+
+func balanceAmount(normal NormalBalance, sumDebit, sumCredit int64) int64 {
+	if normal == NormalCredit {
+		return sumCredit - sumDebit
+	}
+	return sumDebit - sumCredit
+}

--- a/server/internal/ledger/balance_test.go
+++ b/server/internal/ledger/balance_test.go
@@ -1,0 +1,34 @@
+package ledger
+
+import "testing"
+
+func TestBalanceAmount_CreditNormal(t *testing.T) {
+	// Liability account: balance = credits - debits
+	got := balanceAmount(NormalCredit, 200, 1000)
+	if got != 800 {
+		t.Fatalf("expected 800, got %d", got)
+	}
+}
+
+func TestBalanceAmount_DebitNormal(t *testing.T) {
+	// Asset account: balance = debits - credits
+	got := balanceAmount(NormalDebit, 1000, 200)
+	if got != 800 {
+		t.Fatalf("expected 800, got %d", got)
+	}
+}
+
+func TestBalanceAmount_Zero(t *testing.T) {
+	got := balanceAmount(NormalDebit, 500, 500)
+	if got != 0 {
+		t.Fatalf("expected 0, got %d", got)
+	}
+}
+
+func TestBalanceAmount_Negative(t *testing.T) {
+	// A negative balance on a debit-normal account means credits exceed debits.
+	got := balanceAmount(NormalDebit, 100, 300)
+	if got != -200 {
+		t.Fatalf("expected -200, got %d", got)
+	}
+}

--- a/server/internal/ledger/service.go
+++ b/server/internal/ledger/service.go
@@ -15,6 +15,12 @@ type DBTX interface {
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
 }
 
+// QueryableDB extends DBTX with multi-row queries. *sql.DB and *sql.Tx both satisfy this.
+type QueryableDB interface {
+	DBTX
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
+
 // Transaction is the result of a successful PostTransaction call.
 type Transaction struct {
 	ID        string


### PR DESCRIPTION
## Summary

- Add `DeriveBalance` for single-account current balance
- Add `DeriveBalances` for batch multi-account queries
- Add `DeriveBalanceAsOf` for point-in-time historical reporting
- Add `QueryableDB` interface extending `DBTX` with `QueryContext`
- Credit-normal accounts: balance = credits - debits
- Debit-normal accounts: balance = debits - credits
- 4 unit tests for the `balanceAmount` helper

## Linked Issue

Closes https://github.com/shikarii/SpanPay/issues/9

## Validation

```
go test ./internal/ledger/ -v -count=1  # 13 tests pass
go build ./...                           # compiles clean
```

## Risks and Tradeoffs

- `DeriveBalances` uses `ANY($1)` with a string array parameter; some drivers may need `pq.Array()` wrapper at call sites. This will be validated in integration tests.
- Balance queries perform full aggregation each time. For hot accounts with millions of entries, a materialized balance cache may be needed later but is not premature for MVP.