### PR TITLE
Add ledger invariant test suite

### DIFF
--- a/server/internal/ledger/balance.go
+++ b/server/internal/ledger/balance.go
@@ -1,0 +1,114 @@
+package ledger
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// Balance represents a derived account balance at a point in time.
+type Balance struct {
+	AccountID     string
+	NormalBalance NormalBalance
+	Amount        int64
+}
+
+// DeriveBalance computes the current balance for a single account.
+// Credit-normal: SUM(credits) - SUM(debits).
+// Debit-normal:  SUM(debits) - SUM(credits).
+func DeriveBalance(ctx context.Context, tx DBTX, accountID string) (*Balance, error) {
+	var normalBal string
+	var sumDebit, sumCredit int64
+
+	row := tx.QueryRowContext(ctx, `
+		SELECT a.normal_balance,
+		       COALESCE(SUM(e.debit), 0),
+		       COALESCE(SUM(e.credit), 0)
+		FROM ledger_accounts a
+		LEFT JOIN ledger_entries e ON e.account_id = a.id
+		WHERE a.id = $1
+		GROUP BY a.normal_balance`,
+		accountID,
+	)
+	if err := row.Scan(&normalBal, &sumDebit, &sumCredit); err != nil {
+		return nil, fmt.Errorf("derive balance for %s: %w", accountID, err)
+	}
+
+	amount := balanceAmount(NormalBalance(normalBal), sumDebit, sumCredit)
+	return &Balance{
+		AccountID:     accountID,
+		NormalBalance: NormalBalance(normalBal),
+		Amount:        amount,
+	}, nil
+}
+
+// DeriveBalances computes current balances for multiple accounts in one query.
+func DeriveBalances(ctx context.Context, db QueryableDB, accountIDs []string) ([]Balance, error) {
+	if len(accountIDs) == 0 {
+		return nil, nil
+	}
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT a.id, a.normal_balance,
+		       COALESCE(SUM(e.debit), 0),
+		       COALESCE(SUM(e.credit), 0)
+		FROM ledger_accounts a
+		LEFT JOIN ledger_entries e ON e.account_id = a.id
+		WHERE a.id = ANY($1)
+		GROUP BY a.id, a.normal_balance`,
+		accountIDs,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("derive balances: %w", err)
+	}
+	defer rows.Close()
+
+	var balances []Balance
+	for rows.Next() {
+		var id, normalBal string
+		var sumDebit, sumCredit int64
+		if err := rows.Scan(&id, &normalBal, &sumDebit, &sumCredit); err != nil {
+			return nil, fmt.Errorf("scan balance row: %w", err)
+		}
+		balances = append(balances, Balance{
+			AccountID:     id,
+			NormalBalance: NormalBalance(normalBal),
+			Amount:        balanceAmount(NormalBalance(normalBal), sumDebit, sumCredit),
+		})
+	}
+	return balances, rows.Err()
+}
+
+// DeriveBalanceAsOf computes the balance for an account at a specific point in time.
+func DeriveBalanceAsOf(ctx context.Context, tx DBTX, accountID string, asOf time.Time) (*Balance, error) {
+	var normalBal string
+	var sumDebit, sumCredit int64
+
+	row := tx.QueryRowContext(ctx, `
+		SELECT a.normal_balance,
+		       COALESCE(SUM(e.debit), 0),
+		       COALESCE(SUM(e.credit), 0)
+		FROM ledger_accounts a
+		LEFT JOIN ledger_entries e ON e.account_id = a.id AND e.created_at <= $2
+		WHERE a.id = $1
+		GROUP BY a.normal_balance`,
+		accountID, asOf,
+	)
+	if err := row.Scan(&normalBal, &sumDebit, &sumCredit); err != nil {
+		return nil, fmt.Errorf("derive balance as-of for %s: %w", accountID, err)
+	}
+
+	amount := balanceAmount(NormalBalance(normalBal), sumDebit, sumCredit)
+	return &Balance{
+		AccountID:     accountID,
+		NormalBalance: NormalBalance(normalBal),
+		Amount:        amount,
+	}, nil
+}
+
+func balanceAmount(normal NormalBalance, sumDebit, sumCredit int64) int64 {
+	if normal == NormalCredit {
+		return sumCredit - sumDebit
+	}
+	return sumDebit - sumCredit
+}

--- a/server/internal/ledger/balance_test.go
+++ b/server/internal/ledger/balance_test.go
@@ -1,0 +1,34 @@
+package ledger
+
+import "testing"
+
+func TestBalanceAmount_CreditNormal(t *testing.T) {
+	// Liability account: balance = credits - debits
+	got := balanceAmount(NormalCredit, 200, 1000)
+	if got != 800 {
+		t.Fatalf("expected 800, got %d", got)
+	}
+}
+
+func TestBalanceAmount_DebitNormal(t *testing.T) {
+	// Asset account: balance = debits - credits
+	got := balanceAmount(NormalDebit, 1000, 200)
+	if got != 800 {
+		t.Fatalf("expected 800, got %d", got)
+	}
+}
+
+func TestBalanceAmount_Zero(t *testing.T) {
+	got := balanceAmount(NormalDebit, 500, 500)
+	if got != 0 {
+		t.Fatalf("expected 0, got %d", got)
+	}
+}
+
+func TestBalanceAmount_Negative(t *testing.T) {
+	// A negative balance on a debit-normal account means credits exceed debits.
+	got := balanceAmount(NormalDebit, 100, 300)
+	if got != -200 {
+		t.Fatalf("expected -200, got %d", got)
+	}
+}

--- a/server/internal/ledger/invariant_test.go
+++ b/server/internal/ledger/invariant_test.go
@@ -1,0 +1,175 @@
+package ledger
+
+import "testing"
+
+// Posting pattern fixtures: these mirror the rules in docs/spec/ledger-rules.md.
+// Each fixture validates that the entries for a business event are balanced
+// and structurally correct.
+
+func TestPostingPattern_Authorize(t *testing.T) {
+	entries := []Entry{
+		{Account: AcctSettlementPending, Debit: 10000, Credit: 0},
+		{Account: AcctMerchantWalletPending, Debit: 0, Credit: 10000},
+	}
+	if err := ValidateBalanced(entries); err != nil {
+		t.Fatalf("authorize pattern should be balanced: %v", err)
+	}
+}
+
+func TestPostingPattern_Capture(t *testing.T) {
+	entries := []Entry{
+		{Account: AcctMerchantWalletPending, Debit: 10000, Credit: 0},
+		{Account: AcctMerchantWalletAvail, Debit: 0, Credit: 10000},
+		{Account: AcctSettlementAssets, Debit: 10000, Credit: 0},
+		{Account: AcctSettlementPending, Debit: 0, Credit: 10000},
+	}
+	if err := ValidateBalanced(entries); err != nil {
+		t.Fatalf("capture pattern should be balanced: %v", err)
+	}
+}
+
+func TestPostingPattern_Refund(t *testing.T) {
+	entries := []Entry{
+		{Account: AcctMerchantWalletAvail, Debit: 10000, Credit: 0},
+		{Account: AcctSettlementAssets, Debit: 0, Credit: 10000},
+	}
+	if err := ValidateBalanced(entries); err != nil {
+		t.Fatalf("refund pattern should be balanced: %v", err)
+	}
+}
+
+func TestPostingPattern_DisputeWithFee(t *testing.T) {
+	// Transaction amount reversal + dispute fee, all in one transaction.
+	entries := []Entry{
+		{Account: AcctMerchantWalletAvail, Debit: 10000, Credit: 0},
+		{Account: AcctSettlementAssets, Debit: 0, Credit: 10000},
+		{Account: AcctFeeExpense, Debit: 1500, Credit: 0},
+		{Account: AcctSettlementAssets, Debit: 0, Credit: 1500},
+	}
+	if err := ValidateBalanced(entries); err != nil {
+		t.Fatalf("dispute+fee pattern should be balanced: %v", err)
+	}
+}
+
+func TestPostingPattern_DisputeWon(t *testing.T) {
+	// Reverses the dispute amount but not the fee.
+	entries := []Entry{
+		{Account: AcctSettlementAssets, Debit: 10000, Credit: 0},
+		{Account: AcctMerchantWalletAvail, Debit: 0, Credit: 10000},
+	}
+	if err := ValidateBalanced(entries); err != nil {
+		t.Fatalf("dispute-won pattern should be balanced: %v", err)
+	}
+}
+
+func TestPostingPattern_BankPayout(t *testing.T) {
+	entries := []Entry{
+		{Account: AcctMerchantBankAccount, Debit: 10000, Credit: 0},
+		{Account: AcctSettlementAssets, Debit: 0, Credit: 10000},
+	}
+	if err := ValidateBalanced(entries); err != nil {
+		t.Fatalf("bank payout pattern should be balanced: %v", err)
+	}
+}
+
+// Invariant enforcement tests.
+
+func TestInvariant_ConservationOfValue_RejectsOffByOne(t *testing.T) {
+	entries := []Entry{
+		{Account: AcctSettlementPending, Debit: 10000, Credit: 0},
+		{Account: AcctMerchantWalletPending, Debit: 0, Credit: 9999},
+	}
+	if err := ValidateBalanced(entries); err == nil {
+		t.Fatal("should reject entries off by one cent")
+	}
+}
+
+func TestInvariant_SingleSide_RejectsBothPositive(t *testing.T) {
+	entries := []Entry{
+		{Account: AcctSettlementPending, Debit: 500, Credit: 500},
+		{Account: AcctMerchantWalletPending, Debit: 500, Credit: 500},
+	}
+	if err := ValidateBalanced(entries); err == nil {
+		t.Fatal("should reject entry with both debit and credit positive")
+	}
+}
+
+func TestInvariant_SingleSide_RejectsBothZero(t *testing.T) {
+	entries := []Entry{
+		{Account: AcctSettlementPending, Debit: 0, Credit: 0},
+		{Account: AcctMerchantWalletPending, Debit: 0, Credit: 0},
+	}
+	if err := ValidateBalanced(entries); err == nil {
+		t.Fatal("should reject entry with both debit and credit zero")
+	}
+}
+
+func TestInvariant_NegativeAmounts_Rejected(t *testing.T) {
+	entries := []Entry{
+		{Account: AcctSettlementPending, Debit: -1000, Credit: 0},
+		{Account: AcctMerchantWalletPending, Debit: 0, Credit: -1000},
+	}
+	if err := ValidateBalanced(entries); err == nil {
+		t.Fatal("should reject negative amounts")
+	}
+}
+
+func TestInvariant_EmptyAccountName_Rejected(t *testing.T) {
+	entries := []Entry{
+		{Account: "", Debit: 1000, Credit: 0},
+		{Account: AcctMerchantWalletPending, Debit: 0, Credit: 1000},
+	}
+	if err := ValidateBalanced(entries); err == nil {
+		t.Fatal("should reject empty account name")
+	}
+}
+
+func TestInvariant_MinimumTwoEntries(t *testing.T) {
+	entries := []Entry{
+		{Account: AcctSettlementPending, Debit: 1000, Credit: 0},
+	}
+	if err := ValidateBalanced(entries); err == nil {
+		t.Fatal("should reject single entry")
+	}
+}
+
+func TestInvariant_EmptyEntries_Rejected(t *testing.T) {
+	if err := ValidateBalanced(nil); err == nil {
+		t.Fatal("should reject nil entries")
+	}
+	if err := ValidateBalanced([]Entry{}); err == nil {
+		t.Fatal("should reject empty entries")
+	}
+}
+
+// Full lifecycle: authorize -> capture -> refund verifies that all posting
+// patterns in sequence maintain balance consistency.
+func TestFullLifecycle_AuthCaptureRefund(t *testing.T) {
+	patterns := []struct {
+		name    string
+		entries []Entry
+	}{
+		{"authorize", []Entry{
+			{Account: AcctSettlementPending, Debit: 5000, Credit: 0},
+			{Account: AcctMerchantWalletPending, Debit: 0, Credit: 5000},
+		}},
+		{"capture", []Entry{
+			{Account: AcctMerchantWalletPending, Debit: 5000, Credit: 0},
+			{Account: AcctMerchantWalletAvail, Debit: 0, Credit: 5000},
+			{Account: AcctSettlementAssets, Debit: 5000, Credit: 0},
+			{Account: AcctSettlementPending, Debit: 0, Credit: 5000},
+		}},
+		{"refund", []Entry{
+			{Account: AcctMerchantWalletAvail, Debit: 5000, Credit: 0},
+			{Account: AcctSettlementAssets, Debit: 0, Credit: 5000},
+		}},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.name, func(t *testing.T) {
+			if err := ValidateBalanced(p.entries); err != nil {
+				t.Fatalf("%s entries should be balanced: %v", p.name, err)
+			}
+		})
+	}
+}

--- a/server/internal/ledger/service.go
+++ b/server/internal/ledger/service.go
@@ -15,6 +15,12 @@ type DBTX interface {
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
 }
 
+// QueryableDB extends DBTX with multi-row queries. *sql.DB and *sql.Tx both satisfy this.
+type QueryableDB interface {
+	DBTX
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
+
 // Transaction is the result of a successful PostTransaction call.
 type Transaction struct {
 	ID        string


### PR DESCRIPTION
## Summary

- 6 posting pattern tests: authorize, capture, refund, dispute+fee, dispute-won, bank payout
- 7 invariant enforcement tests: conservation of value, single-side, negative amounts, empty accounts, minimum entries
- 1 full lifecycle test: authorize -> capture -> refund sequence
- Total ledger test count: 27 (including prior unit tests)

## Linked Issue

Closes https://github.com/shikarii/SpanPay/issues/10

## Validation

```
go test ./internal/ledger/ -v -count=1  # 27 tests pass
go build ./...                           # compiles clean
```

## Risks and Tradeoffs

- Tests use mock DBTX so they validate domain logic only, not SQL correctness. Integration tests against a real Postgres will come in a later issue.
- Posting pattern fixtures are derived from docs/spec/ledger-rules.md; if rules change, fixtures must be updated in lockstep.