### PR TITLE
Add High-Water Mark out-of-order event handling

### DIFF
--- a/server/internal/state/machine.go
+++ b/server/internal/state/machine.go
@@ -48,6 +48,7 @@ type Transition struct {
 	To         PaymentState
 	Event      Event
 	Idempotent bool
+	Skipped    []Transition // intermediate transitions auto-applied via High-Water Mark
 }
 
 type key struct {
@@ -74,8 +75,35 @@ var table = map[key]PaymentState{
 	{StateDisputed, EventDisputeWon}:           StateCaptured,
 }
 
+// happyPath defines the canonical event chain on the main payment lifecycle.
+// Used by the High-Water Mark logic to compute intermediate transitions
+// when webhook events arrive before earlier synchronous responses commit.
+var happyPath = []struct {
+	event Event
+	from  PaymentState
+	to    PaymentState
+}{
+	{EventPaymentCreate, StateNone, StateCreated},
+	{EventAuthSuccess, StateCreated, StateAuthorized},
+	{EventCaptureRequest, StateAuthorized, StateProcessing},
+	{EventCaptureSuccess, StateProcessing, StateCaptured},
+}
+
+// stateIndex maps happy-path states to their ordinal position.
+var stateIndex = map[PaymentState]int{
+	StateNone:       0,
+	StateCreated:    1,
+	StateAuthorized: 2,
+	StateProcessing: 3,
+	StateCaptured:   4,
+}
+
 // ApplyEvent attempts to transition from current state via event.
 // Returns the transition result, or an error if the transition is invalid.
+//
+// High-Water Mark: if the event implies a state ahead of current on the happy
+// path, intermediate transitions are auto-applied and returned in Skipped.
+//
 // Idempotent: if the payment is already in the target state for this event,
 // the transition is accepted with Idempotent=true and no side effects.
 func ApplyEvent(current PaymentState, event Event) (*Transition, error) {
@@ -83,6 +111,7 @@ func ApplyEvent(current PaymentState, event Event) (*Transition, error) {
 		return nil, fmt.Errorf("%w: state %s rejects all events", ErrTerminalState, current)
 	}
 
+	// Direct transition.
 	target, ok := table[key{current, event}]
 	if ok {
 		return &Transition{From: current, To: target, Event: event}, nil
@@ -96,7 +125,60 @@ func ApplyEvent(current PaymentState, event Event) (*Transition, error) {
 		}
 	}
 
+	// High-Water Mark: try forward-skip on the happy path.
+	if tr, err := tryForwardSkip(current, event); err == nil {
+		return tr, nil
+	}
+
 	return nil, fmt.Errorf("%w: no transition from %s on %s", ErrInvalidTransition, current, event)
+}
+
+// tryForwardSkip checks if the event's normal source state is ahead of current
+// on the happy path. If so, it builds the intermediate transitions needed to
+// reach that source, then applies the event.
+func tryForwardSkip(current PaymentState, event Event) (*Transition, error) {
+	currentIdx, onPath := stateIndex[current]
+	if !onPath {
+		return nil, ErrInvalidTransition
+	}
+
+	// Find the event's normal source state from the transition table.
+	var normalSource PaymentState
+	var found bool
+	for k := range table {
+		if k.event == event {
+			normalSource = k.from
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil, ErrInvalidTransition
+	}
+
+	sourceIdx, sourceOnPath := stateIndex[normalSource]
+	if !sourceOnPath || sourceIdx <= currentIdx {
+		return nil, ErrInvalidTransition
+	}
+
+	// Build intermediate transitions from current to normalSource.
+	var skipped []Transition
+	for i := currentIdx; i < sourceIdx; i++ {
+		step := happyPath[i]
+		skipped = append(skipped, Transition{
+			From:  step.from,
+			To:    step.to,
+			Event: step.event,
+		})
+	}
+
+	finalTarget := table[key{normalSource, event}]
+	return &Transition{
+		From:    current,
+		To:      finalTarget,
+		Event:   event,
+		Skipped: skipped,
+	}, nil
 }
 
 // IsTerminal returns true if the state rejects all further events.

--- a/server/internal/state/machine_test.go
+++ b/server/internal/state/machine_test.go
@@ -45,11 +45,10 @@ func TestInvalidTransitions(t *testing.T) {
 		from  PaymentState
 		event Event
 	}{
-		{StateNone, EventAuthSuccess},
-		{StateCreated, EventCaptureSuccess},
-		{StateAuthorized, EventRefundRequest},
+		// Backward on happy path: source behind current, no HWM.
 		{StateProcessing, EventAuthSuccess},
 		{StateCaptured, EventAuthSuccess},
+		// Off-path state: HWM doesn't apply.
 		{StateDisputed, EventRefundRequest},
 	}
 	for _, tc := range cases {
@@ -216,6 +215,106 @@ func TestPostingsNilForNoLedgerEvents(t *testing.T) {
 	tr2 := &Transition{From: StateCreated, To: StateFailed, Event: EventAuthFailure}
 	if PostingsForTransition(tr2, 0, 0) != nil {
 		t.Fatal("AUTH_FAILURE should produce no postings")
+	}
+}
+
+// --- High-Water Mark tests ---
+
+func TestHWM_CaptureBeforeAuth(t *testing.T) {
+	// CAPTURE_SUCCESS arrives while payment is still CREATED (AUTH_SUCCESS not yet committed).
+	tr, err := ApplyEvent(StateCreated, EventCaptureSuccess)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tr.To != StateCaptured {
+		t.Fatalf("expected CAPTURED, got %s", tr.To)
+	}
+	if len(tr.Skipped) != 2 {
+		t.Fatalf("expected 2 skipped transitions, got %d", len(tr.Skipped))
+	}
+	// Skipped: AUTH_SUCCESS (CREATED→AUTHORIZED), CAPTURE_REQUEST (AUTHORIZED→PROCESSING)
+	if tr.Skipped[0].Event != EventAuthSuccess {
+		t.Fatalf("expected skipped[0]=AUTH_SUCCESS, got %s", tr.Skipped[0].Event)
+	}
+	if tr.Skipped[1].Event != EventCaptureRequest {
+		t.Fatalf("expected skipped[1]=CAPTURE_REQUEST, got %s", tr.Skipped[1].Event)
+	}
+}
+
+func TestHWM_CaptureFromNone(t *testing.T) {
+	// Extreme: CAPTURE_SUCCESS arrives for a payment that hasn't even been created.
+	tr, err := ApplyEvent(StateNone, EventCaptureSuccess)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tr.To != StateCaptured {
+		t.Fatalf("expected CAPTURED, got %s", tr.To)
+	}
+	if len(tr.Skipped) != 3 {
+		t.Fatalf("expected 3 skipped transitions, got %d", len(tr.Skipped))
+	}
+}
+
+func TestHWM_DisputeFromCreated(t *testing.T) {
+	// DISPUTE_CREATED arrives while payment is still CREATED.
+	tr, err := ApplyEvent(StateCreated, EventDisputeCreated)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tr.To != StateDisputed {
+		t.Fatalf("expected DISPUTED, got %s", tr.To)
+	}
+	// Should skip: AUTH_SUCCESS, CAPTURE_REQUEST, CAPTURE_SUCCESS
+	if len(tr.Skipped) != 3 {
+		t.Fatalf("expected 3 skipped, got %d", len(tr.Skipped))
+	}
+}
+
+func TestHWM_AuthFromNone(t *testing.T) {
+	// AUTH_SUCCESS before PAYMENT_CREATE committed.
+	tr, err := ApplyEvent(StateNone, EventAuthSuccess)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tr.To != StateAuthorized {
+		t.Fatalf("expected AUTHORIZED, got %s", tr.To)
+	}
+	if len(tr.Skipped) != 1 || tr.Skipped[0].Event != EventPaymentCreate {
+		t.Fatal("expected 1 skipped PAYMENT_CREATE")
+	}
+}
+
+func TestHWM_PostingsIncludeSkipped(t *testing.T) {
+	// CAPTURE_SUCCESS from CREATED: should produce authorize + capture postings.
+	tr, err := ApplyEvent(StateCreated, EventCaptureSuccess)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	plans := AllPostingsForTransition(tr, 10000, 0)
+	// AUTH_SUCCESS produces 2 entries, CAPTURE_SUCCESS produces 4. CAPTURE_REQUEST produces none.
+	if len(plans) != 2 {
+		t.Fatalf("expected 2 posting plans (authorize + capture), got %d", len(plans))
+	}
+	for _, p := range plans {
+		assertBalanced(t, p.Entries)
+	}
+}
+
+func TestHWM_DisputePostingsFromCreated(t *testing.T) {
+	// DISPUTE_CREATED from CREATED with fee: authorize + capture + dispute postings.
+	tr, err := ApplyEvent(StateCreated, EventDisputeCreated)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	plans := AllPostingsForTransition(tr, 10000, 1500)
+	// Skipped: AUTH_SUCCESS (2 entries), CAPTURE_REQUEST (nil), CAPTURE_SUCCESS (4 entries)
+	// Final: DISPUTE_CREATED (4 entries with fee)
+	// So 3 plans: authorize, capture, dispute
+	if len(plans) != 3 {
+		t.Fatalf("expected 3 posting plans, got %d", len(plans))
+	}
+	for _, p := range plans {
+		assertBalanced(t, p.Entries)
 	}
 }
 

--- a/server/internal/state/postings.go
+++ b/server/internal/state/postings.go
@@ -79,3 +79,19 @@ func PostingsForTransition(t *Transition, amount int64, feeAmount int64) *Postin
 		return nil
 	}
 }
+
+// AllPostingsForTransition returns posting plans for the transition and any
+// skipped intermediate transitions (from High-Water Mark forward-skip).
+// Plans are returned in chronological order: skipped first, then the final event.
+func AllPostingsForTransition(t *Transition, amount int64, feeAmount int64) []*PostingPlan {
+	var plans []*PostingPlan
+	for i := range t.Skipped {
+		if p := PostingsForTransition(&t.Skipped[i], amount, 0); p != nil {
+			plans = append(plans, p)
+		}
+	}
+	if p := PostingsForTransition(t, amount, feeAmount); p != nil {
+		plans = append(plans, p)
+	}
+	return plans
+}


### PR DESCRIPTION
## Summary

- Forward-skip logic on the happy path (NONE → CREATED → AUTHORIZED → PROCESSING → CAPTURED)
- When a webhook event implies a more advanced state, intermediate transitions are auto-applied
- Skipped transitions returned in `Transition.Skipped` for atomic ledger posting
- `AllPostingsForTransition` aggregates posting plans across skipped + final transitions
- Events branching off the happy path (DISPUTE_CREATED, REFUND_REQUEST) also benefit

## Linked Issue

Closes https://github.com/shikarii/SpanPay/issues/12

## Validation

```
go test ./internal/state/ -v -count=1  # all tests pass including 6 new HWM tests
go test ./... -count=1                 # all server tests pass
gofmt -l .                             # clean
go vet ./...                           # clean
```

## Risks and Tradeoffs

- HWM only applies to states on the happy path; off-path states (DISPUTED, REFUNDED_PENDING) as current state cannot forward-skip
- The happy path is defined statically; if new intermediate states are added, the happyPath slice must be updated
- Callers must iterate AllPostingsForTransition and post entries in a single DB transaction for atomicity