### PR TITLE
Add provider error taxonomy with retry classification

### DIFF
--- a/server/internal/provider/errors.go
+++ b/server/internal/provider/errors.go
@@ -1,0 +1,41 @@
+package provider
+
+import "fmt"
+
+// ErrorCode classifies provider-side failures into a finite taxonomy.
+type ErrorCode string
+
+const (
+	ErrInsufficientFunds ErrorCode = "INSUFFICIENT_FUNDS"
+	ErrCardExpired       ErrorCode = "CARD_EXPIRED"
+	ErrFraudBlocked      ErrorCode = "FRAUD_BLOCKED"
+	ErrTechnicalError    ErrorCode = "TECHNICAL_ERROR"
+	ErrRateLimited       ErrorCode = "RATE_LIMITED"
+	ErrAccountClosed     ErrorCode = "ACCOUNT_CLOSED"
+)
+
+// retryable maps each error code to whether the operation can be retried.
+var retryable = map[ErrorCode]bool{
+	ErrInsufficientFunds: false,
+	ErrCardExpired:       false,
+	ErrFraudBlocked:      false,
+	ErrTechnicalError:    true,
+	ErrAccountClosed:     false,
+	ErrRateLimited:       true,
+}
+
+// IsRetryable returns true if the given error code indicates a transient
+// failure that may succeed on retry.
+func IsRetryable(code ErrorCode) bool {
+	return retryable[code]
+}
+
+// ProviderError wraps an ErrorCode with optional detail from the provider.
+type ProviderError struct {
+	Code    ErrorCode
+	Message string
+}
+
+func (e *ProviderError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}

--- a/server/internal/provider/provider.go
+++ b/server/internal/provider/provider.go
@@ -16,13 +16,20 @@ const (
 	StatusPending AttemptStatus = "PENDING"
 )
 
+// PaymentMethod holds tokenized payment details passed to the provider.
+type PaymentMethod struct {
+	Type    string // "card", "bank_transfer", etc.
+	TokenID string // provider-specific token or payment method ID
+}
+
 // NormalizedRequest is the provider-agnostic input for an authorization.
 type NormalizedRequest struct {
-	Amount      int64
-	Currency    string
-	MerchantID  string
-	ExternalRef string
-	Metadata    map[string]string
+	Amount        int64
+	Currency      string
+	MerchantID    string
+	ExternalRef   string
+	PaymentMethod PaymentMethod
+	Metadata      map[string]string
 }
 
 // NormalizedResponse is the provider-agnostic result of any provider operation.
@@ -35,10 +42,12 @@ type NormalizedResponse struct {
 
 // InternalEvent is a normalized webhook event ready for the state machine.
 type InternalEvent struct {
-	PaymentID string
-	Event     state.Event
-	Amount    int64
-	FeeAmount int64
+	PaymentID   string
+	ProviderRef string
+	Event       state.Event
+	Amount      int64
+	FeeAmount   int64
+	Metadata    map[string]string
 }
 
 // Provider defines the contract every PSP adapter must implement.

--- a/server/internal/provider/provider_test.go
+++ b/server/internal/provider/provider_test.go
@@ -1,0 +1,117 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/shikarii/spanpay/server/internal/state"
+)
+
+func TestErrorCodeConstants(t *testing.T) {
+	codes := []ErrorCode{
+		ErrInsufficientFunds, ErrCardExpired, ErrFraudBlocked,
+		ErrTechnicalError, ErrRateLimited, ErrAccountClosed,
+	}
+	seen := make(map[ErrorCode]bool)
+	for _, c := range codes {
+		if c == "" {
+			t.Fatal("empty error code")
+		}
+		if seen[c] {
+			t.Fatalf("duplicate error code: %s", c)
+		}
+		seen[c] = true
+	}
+}
+
+func TestRetryClassification(t *testing.T) {
+	cases := []struct {
+		code      ErrorCode
+		retryable bool
+	}{
+		{ErrInsufficientFunds, false},
+		{ErrCardExpired, false},
+		{ErrFraudBlocked, false},
+		{ErrTechnicalError, true},
+		{ErrRateLimited, true},
+		{ErrAccountClosed, false},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.code), func(t *testing.T) {
+			if got := IsRetryable(tc.code); got != tc.retryable {
+				t.Fatalf("IsRetryable(%s) = %v, want %v", tc.code, got, tc.retryable)
+			}
+		})
+	}
+}
+
+func TestUnknownErrorCodeNotRetryable(t *testing.T) {
+	if IsRetryable("UNKNOWN_CODE") {
+		t.Fatal("unknown error codes should not be retryable")
+	}
+}
+
+func TestProviderErrorMessage(t *testing.T) {
+	err := &ProviderError{Code: ErrCardExpired, Message: "card ending 4242 expired"}
+	got := err.Error()
+	want := "CARD_EXPIRED: card ending 4242 expired"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestAttemptStatusConstants(t *testing.T) {
+	if StatusSuccess != "SUCCESS" {
+		t.Fatal("unexpected SUCCESS constant")
+	}
+	if StatusFailed != "FAILED" {
+		t.Fatal("unexpected FAILED constant")
+	}
+	if StatusPending != "PENDING" {
+		t.Fatal("unexpected PENDING constant")
+	}
+}
+
+func TestNormalizedRequestFields(t *testing.T) {
+	req := NormalizedRequest{
+		Amount:      5000,
+		Currency:    "usd",
+		MerchantID:  "merch_1",
+		ExternalRef: "order_99",
+		PaymentMethod: PaymentMethod{
+			Type:    "card",
+			TokenID: "pm_test_123",
+		},
+		Metadata: map[string]string{"key": "val"},
+	}
+	if req.PaymentMethod.Type != "card" {
+		t.Fatal("unexpected payment method type")
+	}
+	if req.PaymentMethod.TokenID != "pm_test_123" {
+		t.Fatal("unexpected token ID")
+	}
+}
+
+func TestInternalEventFields(t *testing.T) {
+	evt := InternalEvent{
+		PaymentID:   "pay_1",
+		ProviderRef: "pi_abc",
+		Event:       state.EventAuthSuccess,
+		Amount:      10000,
+		FeeAmount:   0,
+		Metadata:    map[string]string{"stripe_id": "evt_123"},
+	}
+	if evt.ProviderRef != "pi_abc" {
+		t.Fatal("unexpected provider ref")
+	}
+	if evt.Event != state.EventAuthSuccess {
+		t.Fatal("unexpected event type")
+	}
+}
+
+func TestRegistryRegisterAndGet(t *testing.T) {
+	reg := NewRegistry()
+	_, err := reg.Get("nonexistent")
+	if err == nil {
+		t.Fatal("expected error for unknown provider")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `ErrorCode` taxonomy (INSUFFICIENT_FUNDS, CARD_EXPIRED, FRAUD_BLOCKED, TECHNICAL_ERROR, RATE_LIMITED, ACCOUNT_CLOSED) with `IsRetryable` classification
- Adds `ProviderError` type for structured error reporting from adapters
- Enhances `NormalizedRequest` with `PaymentMethod` (type + token)
- Enhances `InternalEvent` with `ProviderRef` and `Metadata` fields
- 8 unit tests covering error codes, retry classification, and type fields

## Test plan
- [x] All provider package tests pass (`go test`)
- [x] Full server test suite passes (no regressions)

Closes https://github.com/shikarii/SpanPay/issues/16